### PR TITLE
Control fix

### DIFF
--- a/INDICAM/functions/indiCam_fnc_debug.sqf
+++ b/INDICAM/functions/indiCam_fnc_debug.sqf
@@ -1,0 +1,58 @@
+
+/* Ripppe's debug
+
+
+RAP_fnc_debugLog = {
+    params ["_message", ["_arguments", []]];
+    if (RAP_DEBUG_ON) then {
+        private _formattedMsg = if ([_arguments] call RAP_fnc_isEmptyArray) then {
+            _message;
+        } else {
+            private _messageArr = [_message];
+            _messageArr append _arguments;
+            format _messageArr;
+        };
+        _formattedMsg = ["DEBUG",  _formattedMsg] joinString " --- ";
+
+        if (isMultiplayer) then {
+        _formattedMsg remoteExec ["systemChat", 0, true];
+        } else {
+            systemChat _formattedMsg;
+        };
+    };
+};
+
+
+RipppeToday at 2:31 PM
+@woofer here are the two example use cases for my debug logging:
+
+["Create new patrol group at %1 from composition %2", [_location, _composition]] call RAP_fnc_debugLog;
+If you want to format (inject params) to your debug message use this
+
+["Initializing new patrol"] call RAP_fnc_debugLog;
+
+*/
+
+
+
+// So what do we want it to do?
+// I want a simple as frig just debug thing
+// Every function should contain a local variable with it's name
+// Maybe pass code to this file?
+
+// I will probably want to externally force information put into screen and into log.
+
+
+// ["message string",_toScreenBool,_toLogBool] call indiCam_fnc_debug;
+
+private _message = 	_this select 0;
+private _toScreen = _this select 1;
+private _toLog = 	_this select 2;
+
+
+// Put together the information needed for the report.
+
+
+
+if (indiCam_debug && _toScreen) then {systemchat str _message};
+if (_toLog) then {diag_log str _message};

--- a/INDICAM/functions/indiCam_fnc_manualMode.sqf
+++ b/INDICAM/functions/indiCam_fnc_manualMode.sqf
@@ -1,0 +1,27 @@
+
+
+
+
+// I need to start the camera before this goes online so that indiCam_camera can be created.
+// First, check if the camera exists.
+if (isNil {missionNamespace getVariable "indiCam_camera"}) then {
+
+	// Do the thing that starts the camera
+	_mainStart = [] execVM "INDICAM\indiCam_core_main.sqf";
+	waitUntil {scriptDone _mainStart};
+
+};
+
+
+
+if (indiCam_var_currentMode != "manual") then { // This is a basic toggle
+	if (indiCam_debug) then {systemChat "manual camera controls on"};
+	indiCam_camera camSetTarget indiCam_actor;
+	indiCam_camera camCommand "manual on";
+	indiCam_var_requestMode = "manual";
+} else {
+	indiCam_camera camCommand "manual off";
+	indiCam_var_requestMode = "default";
+	if (indiCam_debug) then {systemChat "manual camera controls off"};
+};
+

--- a/INDICAM/indiCam_core_main.sqf
+++ b/INDICAM/indiCam_core_main.sqf
@@ -5,6 +5,9 @@ comment "-----------------------------------------------------------------------
 
 indiCam_running = true;
 
+// Initialize the keyboard controls
+[] spawn indiCam_core_inputControls;
+
 // Spawning target objects depending on debug mode or not while making sure it's only visible on the local machine.
 if (indiCam_debug) then { // When debug is on, create all logics locally visible
 	

--- a/INDICAM/indiCam_core_mainLoop.sqf
+++ b/INDICAM/indiCam_core_mainLoop.sqf
@@ -70,7 +70,9 @@ if (indiCam_var_currentMode != indiCam_var_requestMode) then {
 			indiCam_appliedVar_ignoreHiddenActor = true;
 
 			// Start manual camera functions
-			
+			indiCam_camera camSetTarget indiCam_actor;
+			indiCam_camera camCommit 0;
+
 			// set this mode to stable
 			indiCam_var_currentMode = "manual";
 			indiCam_var_requestMode = "manual";

--- a/INDICAM/indiCam_gui/indiCam_gui_dialogControl.sqf
+++ b/INDICAM/indiCam_gui/indiCam_gui_dialogControl.sqf
@@ -30,7 +30,7 @@ indiCam_fnc_guiStart = {
 	if (!indiCam_running) then {
 
 		// Actually start the camera before launching any other side scripts
-		[] execVM "INDICAM\indiCam_core_main.sqf";		
+		[] execVM "INDICAM\indiCam_core_main.sqf";
 		
 		// Scene duration override
 		if (indiCam_var_SceneOverrideState) then {
@@ -497,7 +497,7 @@ if (_checkArray) then {
 indiCam_fnc_guiManualMode = {
 
 closeDialog 0;
-[] call indiCam_fnc_manualMode;
+[] spawn indiCam_fnc_manualMode;
 
 };
 

--- a/init.sqf
+++ b/init.sqf
@@ -1,6 +1,5 @@
 
 
-//[] execVM "INDICAM\indiCam_init.sqf"; // initializes indiCam
 [] execVM "INDICAM\indiCam_core_init.sqf"; // initializes indiCam
 
 

--- a/mission.sqm
+++ b/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=9;
 	class ItemIDProvider
 	{
-		nextID=2425;
+		nextID=2426;
 	};
 	class MarkerIDProvider
 	{
@@ -16,24 +16,24 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={22935.336,13.580799,18880.666};
-		dir[]={0.56158561,-0.59730411,-0.57259876};
-		up[]={0.41824201,0.80200994,-0.42644432};
-		aside[]={-0.71394569,2.1548476e-007,-0.70021296};
+		pos[]={22939.268,7.1938062,18874.402};
+		dir[]={0.62974638,-0.5341351,-0.56404746};
+		up[]={0.3978937,0.84538102,-0.35638374};
+		aside[]={-0.66719133,2.30968e-007,-0.74490267};
 	};
 };
 binarizationWanted=0;
 addons[]=
 {
 	"A3_Characters_F",
-	"A3_Props_F_Enoch_Military_Equipment",
-	"A3_Props_F_Enoch_Civilian_Camping"
+	"A3_Props_F_Enoch_Civilian_Camping",
+	"A3_Missions_F_Oldman"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=2;
+		items=3;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -45,6 +45,13 @@ class AddonsMetaData
 		{
 			className="A3_Props_F_Enoch";
 			name="Arma 3 Enoch - Decorative and Mission Objects";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item2
+		{
+			className="A3_Missions_F_Oldman";
+			name="Arma 3 Oldman - Playable Content";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
@@ -143,23 +150,6 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={22940.729,6.3683209,18873.178};
-				angles[]={0.014137167,3.0332775,6.2671809};
-			};
-			side="Empty";
-			class Attributes
-			{
-				name="indiCam_missionControl";
-			};
-			id=2423;
-			type="Land_MultiScreenComputer_01_black_F";
-			atlOffset=0.9579978;
-		};
-		class Item3
-		{
-			dataType="Object";
-			class PositionInfo
-			{
 				position[]={22940.643,5.6529527,18872.096};
 				angles[]={0.012000273,0,6.2671871};
 			};
@@ -171,6 +161,24 @@ class Mission
 			id=2424;
 			type="Land_WoodenTable_02_large_F";
 			atlOffset=-4.1007996e-005;
+		};
+		class Item3
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={22940.303,6.402112,18873.221};
+				angles[]={0.014137167,2.7017522,6.2671809};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				name="indiCam_missioncontrol";
+			};
+			id=2425;
+			type="Item_Laptop_Unfolded";
+			atlOffset=0.00051927567;
 		};
 	};
 };


### PR DESCRIPTION

/* Changelog version 1.31-beta1*/	
///		PRIORITIES / DONE
//FIXED- Manual mode camera no longer resets after scene timer runs out or camera gets too far away from actor or actor gets hidden.
//ADDED- Added CBA keybinds for when CBA is loaded. Without CBA, the legacy keypresses are still working.
//FIXED- Manual camera now targets the actual actor, not any proxy objects.
//REMOVED- Neither script nor mod version gives the cameraman an addaction anymore. Use default F1 or set your own key
//ADDED- Added a centralized debug system. Replacement of old system in code will be ongoing.